### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Render Slack blocks as Markdown
+
+### Other
+- Initialize release-plz
+
+## [0.1.0](https://github.com/dax/slack-blocks-render/releases/tag/v0.1.0) - 2024-06-10
+
+### Added
+- Render Slack blocks as Markdown


### PR DESCRIPTION
## 🤖 New release
* `slack-blocks-render`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).