### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/dax/slack-blocks-render/compare/v0.1.0...v0.1.1) - 2024-06-10
+
+### Fixed
+- Fix `rich_text_list` block parsing
+- Use single char for `bold` and `strike` styles
+- Remove unexpected newline chars
+
+### Other
+- release
+
 ## [0.1.0](https://github.com/dax/slack-blocks-render/releases/tag/v0.1.0) - 2024-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "emojis",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `slack-blocks-render`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/dax/slack-blocks-render/compare/v0.1.0...v0.1.1) - 2024-06-10

### Fixed
- Fix `rich_text_list` block parsing
- Use single char for `bold` and `strike` styles
- Remove unexpected newline chars

### Other
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).