### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/dax/slack-blocks-render/compare/v0.1.1...v0.2.0) - 2024-10-21
+
+### Added
+
+- Resolve Slack user, channel and usergroup ID while rendering
+
 ## [0.1.1](https://github.com/dax/slack-blocks-render/compare/v0.1.0...v0.1.1) - 2024-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `slack-blocks-render`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `slack-blocks-render` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_parameter_count_changed.ron

Failed in:
  slack_blocks_render::render_blocks_as_markdown now takes 2 parameters instead of 1, in /tmp/.tmpjGhpR1/slack-blocks-render/src/markdown.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/dax/slack-blocks-render/compare/v0.1.1...v0.2.0) - 2024-10-21

### Added

- Resolve Slack user, channel and usergroup ID while rendering
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).