### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/dax/slack-blocks-render/compare/v0.2.3...v0.2.4) - 2024-12-09
+
+### Fixed
+
+- Merge identical consecutive styling
+
 ## [0.2.3](https://github.com/dax/slack-blocks-render/compare/v0.2.2...v0.2.3) - 2024-12-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `slack-blocks-render`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/dax/slack-blocks-render/compare/v0.2.3...v0.2.4) - 2024-12-09

### Fixed

- Merge identical consecutive styling
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).