### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/dax/slack-blocks-render/compare/v0.2.5...v0.3.0) - 2024-12-14
+
+### Added
+
+- Add an option to add a custom delimiter for handles
+
 ## [0.2.5](https://github.com/dax/slack-blocks-render/compare/v0.2.4...v0.2.5) - 2024-12-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!         ]
 //!     })),
 //! ];
-//! let markdown_text = render_blocks_as_markdown(blocks, SlackReferences::default());
+//! let markdown_text = render_blocks_as_markdown(blocks, SlackReferences::default(), None);
 //! ```
 //!
 //! ## Usage with Slack references resolution
@@ -82,7 +82,7 @@
 //! //     slack_references.users.insert(slack_user_id, user_info.name);
 //! // }
 //! // Finally, render the blocks as Markdown
-//! let markdown_text = render_blocks_as_markdown(blocks, slack_references);
+//! let markdown_text = render_blocks_as_markdown(blocks, slack_references, None);
 //! ```
 pub mod markdown;
 pub mod references;


### PR DESCRIPTION
## 🤖 New release
* `slack-blocks-render`: 0.2.5 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `slack-blocks-render` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  slack_blocks_render::markdown::render_blocks_as_markdown now takes 3 parameters instead of 2, in /tmp/.tmpABEeGT/slack-blocks-render/src/markdown.rs:15
  slack_blocks_render::render_blocks_as_markdown now takes 3 parameters instead of 2, in /tmp/.tmpABEeGT/slack-blocks-render/src/markdown.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/dax/slack-blocks-render/compare/v0.2.5...v0.3.0) - 2024-12-14

### Added

- Add an option to add a custom delimiter for handles
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).