### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/dax/slack-blocks-render/compare/v0.3.0...v0.4.0) - 2025-03-14
+
+### Added
+
+- Render custom Slack emojis
+
+### Fixed
+
+- Add support for `video` Slack block
+- Use typed emojis references
+- Render links without text as URL
+- Indent nested list items
+- Resolve custom emoji as alias
+- Use CommonMark newline syntax ending lines with `\`
+- Apply styles on emoji blocks
+- Wrap preformatted text with new lines
+- Add newline at the end of quoted text
+
+### Other
+
+- Update dependencies
+
 ## [0.3.0](https://github.com/dax/slack-blocks-render/compare/v0.2.5...v0.3.0) - 2024-12-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slack-blocks-render`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `slack-blocks-render` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SlackReferences.emojis in /tmp/.tmpZ3Metl/slack-blocks-render/src/references.rs:17
  field SlackReferences.emojis in /tmp/.tmpZ3Metl/slack-blocks-render/src/references.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/dax/slack-blocks-render/compare/v0.3.0...v0.4.0) - 2025-03-14

### Added

- Render custom Slack emojis

### Fixed

- Add support for `video` Slack block
- Use typed emojis references
- Render links without text as URL
- Indent nested list items
- Resolve custom emoji as alias
- Use CommonMark newline syntax ending lines with `\`
- Apply styles on emoji blocks
- Wrap preformatted text with new lines
- Add newline at the end of quoted text

### Other

- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).