### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/dax/slack-blocks-render/compare/v0.4.0...v0.4.1) - 2025-03-19
+
+### Other
+
+- Update dependencies
+
 ## [0.4.0](https://github.com/dax/slack-blocks-render/compare/v0.3.0...v0.4.0) - 2025-03-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slack-blocks-render`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/dax/slack-blocks-render/compare/v0.4.0...v0.4.1) - 2025-03-19

### Other

- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).