### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.2](https://github.com/dax/slack-blocks-render/compare/v0.4.1...v0.4.2) - 2025-09-06
+
+### Other
+
+- Update dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slack-blocks-render`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.4.2](https://github.com/dax/slack-blocks-render/compare/v0.4.1...v0.4.2) - 2025-09-06

### Other

- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).