### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/dax/slack-blocks-render/compare/v0.4.2...v0.5.0) - 2026-04-17
+
+### Added
+
+- Add HTML renderer for Slack blocks
+
+### Other
+
+- Update slack-morphism to 2.20 and adapt to typed RichText
+- Replace cargo-checkmate with prek
+
 ## [0.4.1](https://github.com/dax/slack-blocks-render/compare/v0.4.0...v0.4.1) - 2025-03-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slack-blocks-render`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `slack-blocks-render` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SlackReferences.user_id_to_highlight in /tmp/.tmpShMHsH/slack-blocks-render/src/references.rs:19
  field SlackReferences.usergroup_ids_to_highlight in /tmp/.tmpShMHsH/slack-blocks-render/src/references.rs:21
  field SlackReferences.user_id_to_highlight in /tmp/.tmpShMHsH/slack-blocks-render/src/references.rs:19
  field SlackReferences.usergroup_ids_to_highlight in /tmp/.tmpShMHsH/slack-blocks-render/src/references.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.5.0](https://github.com/dax/slack-blocks-render/compare/v0.4.2...v0.5.0) - 2026-04-17

### Added

- Add HTML renderer for Slack blocks

### Other

- Update slack-morphism to 2.20 and adapt to typed RichText
- Replace cargo-checkmate with prek
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).