### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - support slack-morphism 2.22 and refresh dependencies
 
+### Other
+
+- release v0.5.1
+
+## [0.5.2](https://github.com/dax/slack-blocks-render/compare/v0.5.1...v0.5.2) - 2026-05-30
+
+### Added
+
+- support slack-morphism 2.22 and refresh dependencies
+
 ## [0.5.1](https://github.com/dax/slack-blocks-render/compare/v0.5.0...v0.5.1) - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/dax/slack-blocks-render/compare/v0.5.1...v0.5.2) - 2026-05-30
+
+### Added
+
+- support slack-morphism 2.22 and refresh dependencies
+
 ## [0.5.1](https://github.com/dax/slack-blocks-render/compare/v0.5.0...v0.5.1) - 2026-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slack-blocks-render"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "despatma",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-blocks-render"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `slack-blocks-render`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.5.2](https://github.com/dax/slack-blocks-render/compare/v0.5.1...v0.5.2) - 2026-05-30

### Added

- support slack-morphism 2.22 and refresh dependencies

### Other

- release v0.5.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).